### PR TITLE
Monday.com Source Plugin

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -2,11 +2,14 @@ import React from "react"
 import { Layout } from "./src/components/layout"
 import { CssVarsProvider } from '@mui/joy/styles';
 import theme from './src/styles/theme'
+import { PositionsProvider } from './src/components/positions'
 
 export const wrapPageElement = ({ element, props }) => {
   return (
     <CssVarsProvider theme={theme}>
-      <Layout {...props}>{element}</Layout>
+      <PositionsProvider>
+        <Layout {...props}>{element}</Layout>
+      </PositionsProvider>
     </CssVarsProvider>
   )
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,10 @@
+require('dotenv').config({
+  path: `.env.${ process.env.NODE_ENV }`,
+})
+
 module.exports = {
   plugins: [
+    /* image plugins */
     `gatsby-plugin-image`,
     {
       resolve: `gatsby-source-filesystem`,
@@ -8,6 +13,9 @@ module.exports = {
         path: `${__dirname}/src/images`,
       },
     },
+    `gatsby-transformer-sharp`,
+    `gatsby-plugin-sharp`,
+    /* content plugins */
     `gatsby-transformer-yaml`,
     {
       resolve: `gatsby-source-filesystem`,
@@ -37,18 +45,22 @@ module.exports = {
         path: `${__dirname}/src/content/theme`,
       },
     },
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
+    /* custom plugins */
+    {
+      resolve: `gatsby-source-monday`,
+      options: {
+        API_TOKEN: process.env.MONDAY_API_TOKEN,
+      }
+    },
+    /* manifest */
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `gatsby-starter-default`,
-        short_name: `starter`,
+        name: `star-website`,
+        short_name: `star`,
         start_url: `/`,
-        background_color: `#663399`,
-        // This will impact how browsers show your PWA/website
-        // https://css-tricks.com/meta-theme-color-and-trickery/
-        // theme_color: `#663399`,
+        background_color: `#007abc`,
+        theme_color: `#007abc`,
         display: `minimal-ui`,
         icon: `src/images/favicon.png`, // This path is relative to the root of the site.
       },

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -2,11 +2,14 @@ import React from "react"
 import { Layout } from "./src/components/layout"
 import { CssVarsProvider } from '@mui/joy/styles';
 import theme from './src/styles/theme'
+import { PositionsProvider } from './src/components/positions'
 
 export const wrapPageElement = ({ element, props }) => {
   return (
     <CssVarsProvider theme={theme}>
-      <Layout {...props}>{element}</Layout>
+      <PositionsProvider>
+        <Layout {...props}>{element}</Layout>
+      </PositionsProvider>
     </CssVarsProvider>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/inter": "^5.0.8",
+        "@mui/icons-material": "^5.14.19",
         "@mui/joy": "^5.0.0-beta.7",
         "change-case": "^4.1.2",
         "gatsby": "^5.12.4",
@@ -1871,9 +1872,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+      "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2210,9 +2211,9 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
+      "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.5.1"
       },
@@ -3016,12 +3017,37 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.10.tgz",
-      "integrity": "sha512-kPHu/NhZq1k+vSZR5wq3AyUfD4bnfWAeuKpps0+8PS7ZHQ2Lyv1cXJh+PlFdCIOa0PK98rk3JPwMzS8BMhdHwQ==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.20.tgz",
+      "integrity": "sha512-fXoGe8VOrIYajqALysFuyal1q1YmBARqJ3tmnWYDVl0scu8f6h6tZQbS2K8BY28QwkWNGyv4WRfuUkzN5HR3Ow==",
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.14.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.19.tgz",
+      "integrity": "sha512-yjP8nluXxZGe3Y7pS+yxBV+hWZSsSBampCxkZwaw+1l+feL+rfP74vbEFbMrX/Kil9I/Y1tWfy5bs/eNvwNpWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/joy": {
@@ -3064,13 +3090,63 @@
         }
       }
     },
-    "node_modules/@mui/private-theming": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.10.tgz",
-      "integrity": "sha512-f67xOj3H06wWDT9xBg7hVL/HSKNF+HG1Kx0Pm23skkbEqD2Ef2Lif64e5nPdmWVv+7cISCYtSuE2aeuzrZe78w==",
+    "node_modules/@mui/material": {
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.20.tgz",
+      "integrity": "sha512-SUcPZnN6e0h1AtrDktEl76Dsyo/7pyEUQ+SAVe9XhHg/iliA0b4Vo+Eg4HbNkELsMbpDsUF4WHp7rgflPG7qYQ==",
+      "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.22.15",
-        "@mui/utils": "^5.14.10",
+        "@babel/runtime": "^7.23.4",
+        "@mui/base": "5.0.0-beta.26",
+        "@mui/core-downloads-tracker": "^5.14.20",
+        "@mui/system": "^5.14.20",
+        "@mui/types": "^7.2.10",
+        "@mui/utils": "^5.14.20",
+        "@types/react-transition-group": "^4.4.9",
+        "clsx": "^2.0.0",
+        "csstype": "^3.1.2",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/base": {
+      "version": "5.0.0-beta.26",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.26.tgz",
+      "integrity": "sha512-gPMRKC84VRw+tjqYoyBzyrBUqHQucMXdlBpYazHa5rCXrb91fYEQk5SqQ2U5kjxx9QxZxTBvWAmZ6DblIgaGhQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.23.4",
+        "@floating-ui/react-dom": "^2.0.4",
+        "@mui/types": "^7.2.10",
+        "@mui/utils": "^5.14.20",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.0.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3078,7 +3154,40 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "peer": true
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.20.tgz",
+      "integrity": "sha512-WV560e1vhs2IHCh0pgUaWHznrcrVoW9+cDCahU1VTkuwPokWVvb71ccWQ1f8Y3tRBPPcNkU2dChkkRJChLmQlQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.4",
+        "@mui/utils": "^5.14.20",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -3091,11 +3200,11 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.10.tgz",
-      "integrity": "sha512-EJckxmQHrsBvDbFu1trJkvjNw/1R7jfNarnqPSnL+jEQawCkQIqVELWLrlOa611TFtxSJGkdUfCFXeJC203HVg==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.20.tgz",
+      "integrity": "sha512-Vs4nGptd9wRslo9zeRkuWcZeIEp+oYbODy+fiZKqqr4CH1Gfi9fdP0Q1tGYk8OiJ2EPB/tZSAyOy62Hyp/iP7g==",
       "dependencies": {
-        "@babel/runtime": "^7.22.15",
+        "@babel/runtime": "^7.23.4",
         "@emotion/cache": "^11.11.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -3105,7 +3214,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
@@ -3122,15 +3231,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.10.tgz",
-      "integrity": "sha512-QQmtTG/R4gjmLiL5ECQ7kRxLKDm8aKKD7seGZfbINtRVJDyFhKChA1a+K2bfqIAaBo1EMDv+6FWNT1Q5cRKjFA==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.20.tgz",
+      "integrity": "sha512-jKOGtK4VfYZG5kdaryUHss4X6hzcfh0AihT8gmnkfqRtWP7xjY+vPaUhhuSeibE5sqA5wCtdY75z6ep9pxFnIg==",
       "dependencies": {
-        "@babel/runtime": "^7.22.15",
-        "@mui/private-theming": "^5.14.10",
-        "@mui/styled-engine": "^5.14.10",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.10",
+        "@babel/runtime": "^7.23.4",
+        "@mui/private-theming": "^5.14.20",
+        "@mui/styled-engine": "^5.14.19",
+        "@mui/types": "^7.2.10",
+        "@mui/utils": "^5.14.20",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -3140,7 +3249,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -3161,11 +3270,11 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+      "version": "7.2.10",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.10.tgz",
+      "integrity": "sha512-wX1vbDC+lzF7FlhT6A3ffRZgEoKWPF8VqRoTu4lZwouFX2t90KyCMsgepMw5DxLak1BSp/KP86CmtZttikb/gQ==",
       "peerDependencies": {
-        "@types/react": "*"
+        "@types/react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3174,12 +3283,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.10.tgz",
-      "integrity": "sha512-Rn+vYQX7FxkcW0riDX/clNUwKuOJFH45HiULxwmpgnzQoQr3A0lb+QYwaZ+FAkZrR7qLoHKmLQlcItu6LT0y/Q==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.20.tgz",
+      "integrity": "sha512-Y6yL5MoFmtQml20DZnaaK1znrCEwG6/vRSzW8PKOTrzhyqKIql0FazZRUR7sA5EPASgiyKZfq0FPwISRXm5NdA==",
       "dependencies": {
-        "@babel/runtime": "^7.22.15",
-        "@types/prop-types": "^15.7.5",
+        "@babel/runtime": "^7.23.4",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -3188,7 +3297,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -4323,9 +4432,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/reach__router": {
       "version": "1.3.11",
@@ -4343,6 +4452,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+      "peer": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -7115,6 +7233,16 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -14244,6 +14372,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -18263,9 +18407,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+      "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -18539,9 +18683,9 @@
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
+      "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
       "requires": {
         "@floating-ui/dom": "^1.5.1"
       }
@@ -19168,9 +19312,17 @@
       }
     },
     "@mui/core-downloads-tracker": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.10.tgz",
-      "integrity": "sha512-kPHu/NhZq1k+vSZR5wq3AyUfD4bnfWAeuKpps0+8PS7ZHQ2Lyv1cXJh+PlFdCIOa0PK98rk3JPwMzS8BMhdHwQ=="
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.20.tgz",
+      "integrity": "sha512-fXoGe8VOrIYajqALysFuyal1q1YmBARqJ3tmnWYDVl0scu8f6h6tZQbS2K8BY28QwkWNGyv4WRfuUkzN5HR3Ow=="
+    },
+    "@mui/icons-material": {
+      "version": "5.14.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.19.tgz",
+      "integrity": "sha512-yjP8nluXxZGe3Y7pS+yxBV+hWZSsSBampCxkZwaw+1l+feL+rfP74vbEFbMrX/Kil9I/Y1tWfy5bs/eNvwNpWw==",
+      "requires": {
+        "@babel/runtime": "^7.23.4"
+      }
     },
     "@mui/joy": {
       "version": "5.0.0-beta.7",
@@ -19187,55 +19339,98 @@
         "prop-types": "^15.8.1"
       }
     },
-    "@mui/private-theming": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.10.tgz",
-      "integrity": "sha512-f67xOj3H06wWDT9xBg7hVL/HSKNF+HG1Kx0Pm23skkbEqD2Ef2Lif64e5nPdmWVv+7cISCYtSuE2aeuzrZe78w==",
+    "@mui/material": {
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.20.tgz",
+      "integrity": "sha512-SUcPZnN6e0h1AtrDktEl76Dsyo/7pyEUQ+SAVe9XhHg/iliA0b4Vo+Eg4HbNkELsMbpDsUF4WHp7rgflPG7qYQ==",
+      "peer": true,
       "requires": {
-        "@babel/runtime": "^7.22.15",
-        "@mui/utils": "^5.14.10",
+        "@babel/runtime": "^7.23.4",
+        "@mui/base": "5.0.0-beta.26",
+        "@mui/core-downloads-tracker": "^5.14.20",
+        "@mui/system": "^5.14.20",
+        "@mui/types": "^7.2.10",
+        "@mui/utils": "^5.14.20",
+        "@types/react-transition-group": "^4.4.9",
+        "clsx": "^2.0.0",
+        "csstype": "^3.1.2",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "dependencies": {
+        "@mui/base": {
+          "version": "5.0.0-beta.26",
+          "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.26.tgz",
+          "integrity": "sha512-gPMRKC84VRw+tjqYoyBzyrBUqHQucMXdlBpYazHa5rCXrb91fYEQk5SqQ2U5kjxx9QxZxTBvWAmZ6DblIgaGhQ==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.23.4",
+            "@floating-ui/react-dom": "^2.0.4",
+            "@mui/types": "^7.2.10",
+            "@mui/utils": "^5.14.20",
+            "@popperjs/core": "^2.11.8",
+            "clsx": "^2.0.0",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "peer": true
+        }
+      }
+    },
+    "@mui/private-theming": {
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.20.tgz",
+      "integrity": "sha512-WV560e1vhs2IHCh0pgUaWHznrcrVoW9+cDCahU1VTkuwPokWVvb71ccWQ1f8Y3tRBPPcNkU2dChkkRJChLmQlQ==",
+      "requires": {
+        "@babel/runtime": "^7.23.4",
+        "@mui/utils": "^5.14.20",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/styled-engine": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.10.tgz",
-      "integrity": "sha512-EJckxmQHrsBvDbFu1trJkvjNw/1R7jfNarnqPSnL+jEQawCkQIqVELWLrlOa611TFtxSJGkdUfCFXeJC203HVg==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.20.tgz",
+      "integrity": "sha512-Vs4nGptd9wRslo9zeRkuWcZeIEp+oYbODy+fiZKqqr4CH1Gfi9fdP0Q1tGYk8OiJ2EPB/tZSAyOy62Hyp/iP7g==",
       "requires": {
-        "@babel/runtime": "^7.22.15",
+        "@babel/runtime": "^7.23.4",
         "@emotion/cache": "^11.11.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/system": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.10.tgz",
-      "integrity": "sha512-QQmtTG/R4gjmLiL5ECQ7kRxLKDm8aKKD7seGZfbINtRVJDyFhKChA1a+K2bfqIAaBo1EMDv+6FWNT1Q5cRKjFA==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.20.tgz",
+      "integrity": "sha512-jKOGtK4VfYZG5kdaryUHss4X6hzcfh0AihT8gmnkfqRtWP7xjY+vPaUhhuSeibE5sqA5wCtdY75z6ep9pxFnIg==",
       "requires": {
-        "@babel/runtime": "^7.22.15",
-        "@mui/private-theming": "^5.14.10",
-        "@mui/styled-engine": "^5.14.10",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.10",
+        "@babel/runtime": "^7.23.4",
+        "@mui/private-theming": "^5.14.20",
+        "@mui/styled-engine": "^5.14.19",
+        "@mui/types": "^7.2.10",
+        "@mui/utils": "^5.14.20",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/types": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+      "version": "7.2.10",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.10.tgz",
+      "integrity": "sha512-wX1vbDC+lzF7FlhT6A3ffRZgEoKWPF8VqRoTu4lZwouFX2t90KyCMsgepMw5DxLak1BSp/KP86CmtZttikb/gQ==",
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.10.tgz",
-      "integrity": "sha512-Rn+vYQX7FxkcW0riDX/clNUwKuOJFH45HiULxwmpgnzQoQr3A0lb+QYwaZ+FAkZrR7qLoHKmLQlcItu6LT0y/Q==",
+      "version": "5.14.20",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.20.tgz",
+      "integrity": "sha512-Y6yL5MoFmtQml20DZnaaK1znrCEwG6/vRSzW8PKOTrzhyqKIql0FazZRUR7sA5EPASgiyKZfq0FPwISRXm5NdA==",
       "requires": {
-        "@babel/runtime": "^7.22.15",
-        "@types/prop-types": "^15.7.5",
+        "@babel/runtime": "^7.23.4",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -20010,9 +20205,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "@types/reach__router": {
       "version": "1.3.11",
@@ -20030,6 +20225,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+      "peer": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/responselike": {
@@ -22087,6 +22291,16 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -27110,6 +27324,18 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
           "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
         }
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/inter": "^5.0.8",
+    "@mui/icons-material": "^5.14.19",
     "@mui/joy": "^5.0.0-beta.7",
     "change-case": "^4.1.2",
     "gatsby": "^5.12.4",

--- a/plugins/gatsby-source-monday/gatsby-node.js
+++ b/plugins/gatsby-source-monday/gatsby-node.js
@@ -1,0 +1,95 @@
+const axios = require('axios')
+const fs = require('fs')
+
+const API_URL = `https://api.monday.com/v2`
+const axiosOptions = { headers: {} }
+
+//
+
+const query = `query {
+  boards(ids:[3488406941]) {
+    columns {
+      id
+      title
+      settings_str
+    }
+    items {
+      id
+      name
+      column_values {
+        title
+        value
+      }
+    }
+  }
+}`
+
+async function fetchBoardData(options) {
+  try {
+    const response = await axios.post(API_URL, { query }, options)
+    if (response?.status !== 200 || !response?.data) {
+      return
+    }
+    return response.data.data.boards[0]
+  } catch (error) {
+    console.error(error)
+    return []
+  }
+}
+
+
+// columns (keys) end up as item object properties (values)
+const fieldMap = {
+  'RENCI Division/Project Team': 'division',
+  'Student Identified?': 'filled',
+  'Position Title': 'title',
+  'Estimated Start Date': 'startDate',
+}
+
+/* Turns column and row data into an array of position objects
+ * with fields defined by `fieldMap` 
+ * 
+ * @param {array}  columns  Monday response columns defined in query above.
+ * @param {array}  items    Monday response items defined in query above.
+ * 
+ * @return {array}  position objects.
+ * */
+function assembleBoardData({ columns, items }) {
+  return items.reduce((acc, item) => {
+    const { id, name, column_values } = item
+    const extractedColumns = column_values
+      .reduce((acc, { title, value }) => {
+        if (title in fieldMap) {
+          acc[fieldMap[title]] = JSON.parse(value)
+        }
+        return acc
+      }, {})
+    acc.push({ id, manager: name, ...extractedColumns })
+    return acc
+  }, [])
+}
+
+exports.sourceNodes = async (gatsbyApi, pluginOptions) => {
+  try {
+    axiosOptions.headers.Authorization = `bearer ${ pluginOptions.API_TOKEN }`
+    const { actions, createContentDigest, createNodeId } = gatsbyApi
+    const boardData = await fetchBoardData(axiosOptions)
+    const positionData = assembleBoardData(boardData)
+    // create nods from positions data.
+    for (const position of positionData) {
+      actions.createNode({
+        ...position,
+        parent: null,
+        children: [],
+        internal: {
+          type: 'MondayItem',
+          contentDigest: createContentDigest(position)
+        }
+      })
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+

--- a/plugins/gatsby-source-monday/gatsby-node.js
+++ b/plugins/gatsby-source-monday/gatsby-node.js
@@ -7,18 +7,24 @@ const axiosOptions = { headers: {} }
 //
 
 const query = `query {
-  boards(ids:[3488406941]) {
+  boards(ids:[5267641585]) {
     columns {
       id
       title
-      settings_str
     }
-    items {
+    groups(ids:["group_title"]) {
       id
-      name
-      column_values {
-        title
-        value
+      title
+      items_page {
+        cursor
+        items {
+          id
+          name
+          column_values {
+            id
+            text
+          }
+        }
       }
     }
   }
@@ -40,10 +46,12 @@ async function fetchBoardData(options) {
 
 // columns (keys) end up as item object properties (values)
 const fieldMap = {
-  'RENCI Division/Project Team': 'division',
-  'Student Identified?': 'filled',
-  'Position Title': 'title',
-  'Estimated Start Date': 'startDate',
+  'Program': 'program',
+  'RENCI Domain': 'domain',
+  'Group': 'group',
+  'Project/Team Name': 'division',
+  'Semester': 'semester',
+  'Anticipated Start Date': 'startDate',
 }
 
 /* Turns column and row data into an array of position objects

--- a/plugins/gatsby-source-monday/package-lock.json
+++ b/plugins/gatsby-source-monday/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": "gatsby-source-monday",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gatsby-source-monday",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "axios": "^1.5.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    }
+  }
+}

--- a/plugins/gatsby-source-monday/package.json
+++ b/plugins/gatsby-source-monday/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gatsby-source-monday",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "axios": "^1.5.0"
+  }
+}

--- a/src/components/container.js
+++ b/src/components/container.js
@@ -5,6 +5,7 @@ export const Container = ({
   children,
   className = 'container', // allows custom styling
   maxWidth = '1200px',
+  sx = {},
 }) => {
   return (
     <Sheet
@@ -13,8 +14,9 @@ export const Container = ({
         // ensure this component fills the available
         // space in its parent.
         width: '100%', flex: 1, alignSelf: 'stretch',
-        maxWidth,
+        maxWidth, margin: 'auto',
         backgroundColor: 'transparent',
+        ...sx,
       }}
     >
       { children }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,33 +1,30 @@
 import React, { Fragment } from 'react'
 import { CssBaseline, Sheet } from '@mui/joy'
-
 import Header from './header'
 import Footer from './footer'
 
-export const Layout = ({ children }) => {
-  return (
-    <Fragment>
-      <CssBaseline />
-      <Sheet sx={{
-        height: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        pre: { whiteSpace: 'pre-wrap', p: 4 },
-        'main': {
-          flex: 1,
-        },
-      }}>
-        <Header />
-        
-        <main>
-          { children }
-        </main>
+export const Layout = ({ children }) => (
+  <Fragment>
+    <CssBaseline />
+    <Sheet sx={{
+      height: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+      pre: { whiteSpace: 'pre-wrap', p: 4 },
+      'main': {
+        flex: 1,
+      },
+    }}>
+      <Header />
+      
+      <main>
+        { children }
+      </main>
 
-        <Footer />
+      <Footer />
 
-      </Sheet>
-    </Fragment>
-  )
-}
+    </Sheet>
+  </Fragment>
+)
 
 export default Layout

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -10,7 +10,6 @@ export const Layout = ({ children }) => (
       height: '100vh',
       display: 'flex',
       flexDirection: 'column',
-      pre: { whiteSpace: 'pre-wrap', p: 4 },
       'main': {
         flex: 1,
       },

--- a/src/components/positions/context.js
+++ b/src/components/positions/context.js
@@ -5,8 +5,16 @@ export const usePositions = () => useContext(PositionsContext)
 
 /*
  * This utility function turns strings in an array
- * into properrties in an object, all of whose values
+ * into properties in an object, all of whose values
  * are set to a given initial value.
+ * 
+ * @param      {string[]} keysArray   strings to be used as
+ *                                    the returned object keys 
+ * @param      {any}      initialValue=''   value to initialize
+ *                                          the object with
+ * 
+ * @return     {object}   incoming strings as properties and
+ *                        values equal to the initial value.
  */
 function objectFromArray(keysArray, initialValue = '') {
   if (
@@ -20,10 +28,8 @@ function objectFromArray(keysArray, initialValue = '') {
 }
 
 export const PositionsProvider = ({ children }) => {
-  /*
-   * this query grabs all the position data that is
-   * coming directly from the monday source plugin.
-   */
+  // this query grabs all the position data that is
+  // coming directly from the monday source plugin.
   const data = useStaticQuery(graphql`
     query PositionsQuery {
       allMondayColumn {
@@ -57,21 +63,24 @@ export const PositionsProvider = ({ children }) => {
   // extract the data nodes.
   const columns = useMemo(() => data?.allMondayColumn?.nodes ?? [], [data])
   const positions = useMemo(() => data?.allMondayItem?.nodes ?? [], [data])
-  // filters is an object whose keys are position
+  // `filters` is an object whose keys are position
   // properties and whose values are ones to match
-  // on positions in the respective property.
+  // on positions in the respective property,
+  // e.g., { program: '', domain: 'Research', ... }.
   const [filters, setFilters] = useState(() => objectFromArray(columns), [columns])
-  // activeFilters is an array of filter keys that are in use
+  // activeFilters is an array of filter keys that are in use,
+  // e.g., ['domain'].
   const activeFilters = useMemo(() => Object.keys(filters)
     .filter(key => !!filters[key]), [filters])
-  // updating on changes to the filters, filteredPositions
-  // will contain those positions that match active filter values.
-  // if there are no active filters, this returns all positions.
+  // `filteredPositions` contains those positions that
+  // match active filter values, and it updates on
+  // changes to `filters`. if there are no active filters,
+  // all positions are returned.
   const filteredPositions = useMemo(() => {
     if (!activeFilters.length) {
       return positions
     }
-    // this is an inclusive or. which may not match user expectations. 
+    // this is an inclusive or, which may not match user expectations. 
     return positions
       .filter(position => {
         return activeFilters
@@ -79,11 +88,12 @@ export const PositionsProvider = ({ children }) => {
       })
   }, [activeFilters, filters, positions])
 
+  // sets all filter properties to the empty string.
   const resetFilters = () => setFilters(objectFromArray(columns))
 
   if (!data) {
-    // todo: implement a more appropriate loading indicator
-    return 'Loading...'
+    // todo: implement a more appropriate fallback.
+    return 'There is no data.'
   }
 
   return (
@@ -92,7 +102,11 @@ export const PositionsProvider = ({ children }) => {
         // monday board columns.
         // this gets turned into filters ui,
         // which can probably just happen here.
-        // ^ todo
+        // ^ todo: turn columns into filters here.
+        // there is no need for any part of this application
+        // to know anything about monday.com, and "columns"
+        // is an implementation detail of monday.com that
+        // can be handled here.
         columns,
         // all positions are available,..
         positions,
@@ -101,9 +115,9 @@ export const PositionsProvider = ({ children }) => {
         // all filtering functionality lives
         // inside this filters property
         filters: {
-          // alias for filters
+          // alias for `filters`
           current: filters,
-          // alias for setFilters
+          // alias for `setFilters`
           set: setFilters,
           // clear all filters
           reset: resetFilters,

--- a/src/components/positions/context.js
+++ b/src/components/positions/context.js
@@ -1,0 +1,116 @@
+import React, { createContext, useContext, useMemo, useState } from 'react'
+import { graphql, useStaticQuery } from 'gatsby'
+const PositionsContext = createContext({ })
+export const usePositions = () => useContext(PositionsContext)
+
+/*
+ * This utility function turns strings in an array
+ * into properrties in an object, all of whose values
+ * are set to a given initial value.
+ */
+function objectFromArray(keysArray, initialValue = '') {
+  if (
+    !Array.isArray(keysArray) ||
+    keysArray.some(v => typeof value !== 'string')
+  ) { return {} }
+  return keysArray.reduce((acc, col) => {
+    acc[col.field] = initialValue
+    return acc
+  }, {})
+}
+
+export const PositionsProvider = ({ children }) => {
+  /*
+   * this query grabs all the position data that is
+   * coming directly from the monday source plugin.
+   */
+  const data = useStaticQuery(graphql`
+    query PositionsQuery {
+      allMondayColumn {
+        nodes {
+          id
+          field
+          title
+          options
+        }
+      }
+      allMondayItem {
+        nodes {
+          id
+          name
+          program
+          domain
+          group
+          division
+          semester
+          startDate
+          duration
+          abstract
+          description
+          pay
+          url
+        }
+      }
+    }
+  `)
+
+  // extract the data nodes.
+  const columns = useMemo(() => data?.allMondayColumn?.nodes ?? [], [data])
+  const positions = useMemo(() => data?.allMondayItem?.nodes ?? [], [data])
+  // filters is an object whose keys are position
+  // properties and whose values are ones to match
+  // on positions in the respective property.
+  const [filters, setFilters] = useState(() => objectFromArray(columns), [columns])
+  // activeFilters is an array of filter keys that are in use
+  const activeFilters = useMemo(() => Object.keys(filters)
+    .filter(key => !!filters[key]), [filters])
+  // updating on changes to the filters, filteredPositions
+  // will contain those positions that match active filter values.
+  // if there are no active filters, this returns all positions.
+  const filteredPositions = useMemo(() => {
+    if (!activeFilters.length) {
+      return positions
+    }
+    // this is an inclusive or. which may not match user expectations. 
+    return positions
+      .filter(position => {
+        return activeFilters
+          .some(key => position[key] === filters[key])
+      })
+  }, [activeFilters, filters, positions])
+
+  const resetFilters = () => setFilters(objectFromArray(columns))
+
+  if (!data) {
+    // todo: implement a more appropriate loading indicator
+    return 'Loading...'
+  }
+
+  return (
+    <PositionsContext.Provider
+      value={{
+        // monday board columns.
+        // this gets turned into filters ui,
+        // which can probably just happen here.
+        // ^ todo
+        columns,
+        // all positions are available,..
+        positions,
+        // ...as well as the filtered positions.
+        filteredPositions,
+        // all filtering functionality lives
+        // inside this filters property
+        filters: {
+          // alias for filters
+          current: filters,
+          // alias for setFilters
+          set: setFilters,
+          // clear all filters
+          reset: resetFilters,
+          // array of active filter keys
+          active: activeFilters,
+        },
+      }}
+    >{ children }</PositionsContext.Provider>
+  )
+}

--- a/src/components/positions/filters-tray.js
+++ b/src/components/positions/filters-tray.js
@@ -1,0 +1,112 @@
+import React, { useRef } from 'react'
+import { Card, FormControl, FormLabel, IconButton, Option, Select, Stack } from '@mui/joy'
+import { Close as ClearSelectionIcon } from '@mui/icons-material'
+import { usePositions } from './context'
+
+const FilterSelect = ({ field, label, options, title, value, onChange }) => {
+  const action = useRef(null)
+
+  return (
+    <FormControl>
+      <FormLabel
+        id={ `${ field }-filter-label` }
+        htmlFor={ `${ field }-filter-select` }
+      >{ label }</FormLabel>
+      <Select
+        value={ value }
+        onChange={ onChange }
+        placeholder={ title }
+        slotProps={{
+          button: {
+            id: `${ field }-filter-select`,
+            'aria-labelledby': `${ field }-filter-label ${ field }-filter-select`,
+            p: 3,
+          },
+        }}
+        {
+          // this block conditionally passes props to our Select component
+          // to display the clear button and remove select indicator
+          // when user has selected a value and remove the clear button and
+          // replace the select indicator after its use.
+          ...(value && {
+            endDecorator: (
+              <IconButton
+                size="sm"
+                variant="plain"
+                color="neutral"
+                onMouseDown={
+                  // don't open the popup when clicking this button.
+                  event => event.stopPropagation()
+                }
+                onClick={
+                  // update selection
+                  // and put focus in sensible place after using this button.
+                  event => {
+                    onChange(event, '')
+                    action.current?.focusVisible()
+                  }
+                }
+              >
+                <ClearSelectionIcon />
+              </IconButton>
+            ),
+            indicator: null,
+          })
+        }
+      >
+        {
+          options.map(option => (
+            <Option
+              key={ `${ field }-option-${ option }` }
+              value={ option }
+            >{ option }</Option>
+          ))
+        }
+      </Select>
+    </FormControl>
+  )
+}
+
+export const FiltersTray = () => {
+  const { columns, filters } = usePositions()
+
+  const handleChangeFilter = field => (event, newValue) => {
+    filters.set({ ...filters.current, [field]: newValue ?? '' })
+  }
+
+  const handleClickClearFilters = () => {
+    filters.reset()
+  }
+
+  return (
+    <Card variant="soft">
+      <Stack
+        direction="row"
+        alignItems="flex-end"
+        gap={ 2 }
+        sx={{ '.MuiFormControl-root': { flex: 1, } }}
+      >
+        {
+          columns.filter(c => !!c.field).map(column => (
+            <FilterSelect
+              key={ `${ column.field }-filter` }
+              field={ column.field }
+              label={ column.title }
+              options={ column.options }
+              value={ filters.current[column.field] }
+              onChange={ handleChangeFilter(column.field) }
+            />
+          ))
+        }
+        {
+          filters.active.length > 0 && (
+            <IconButton onClick={ handleClickClearFilters }>
+              <ClearSelectionIcon />
+            </IconButton>
+          )
+        }
+      </Stack>
+    </Card>
+  )
+}
+

--- a/src/components/positions/index.js
+++ b/src/components/positions/index.js
@@ -1,0 +1,3 @@
+export * from './context'
+export * from './filters-tray'
+export * from './positions-list'

--- a/src/components/positions/position-preview.js
+++ b/src/components/positions/position-preview.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Box, Card } from '@mui/joy'
+
+export const PositionPreview = ({ position }) => {
+
+  return (
+    <Card variant="soft">
+      <Box
+        component="pre"
+        sx={{ fontSize: '75%' }}
+      >
+        { JSON.stringify(position, null, 2) }
+      </Box>
+    </Card>
+  )
+}

--- a/src/components/positions/positions-list.js
+++ b/src/components/positions/positions-list.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Stack, Typography } from '@mui/joy'
+import { usePositions } from './context'
+import { PositionPreview } from './position-preview'
+
+export const PositionsList = () => {
+  const { filteredPositions } = usePositions()
+
+  if (filteredPositions.length === 0) {
+    return (
+      <Stack
+        justifyContent="center"
+        alignItems="center"
+        sx={{ height: '300px' }}
+      >
+        <Typography
+          level="body-lg"
+          align="center"
+          variant="soft"
+          sx={{ p: 2 }}
+        >
+          No positions match your search criteria!
+        </Typography>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap={ 2 }>
+      {
+        filteredPositions.map(position => (
+          <PositionPreview
+            key={ position.id }
+            position={ position }
+          />
+        ))
+      }
+    </Stack>
+
+  )
+}

--- a/src/pages/positions.js
+++ b/src/pages/positions.js
@@ -6,7 +6,7 @@ import { Seo } from '../components/seo'
 
 const PositionsPage = ({ data }) => {
 
-  const positions = data.allMondayItem.nodes
+  const positions = data?.allMondayItem?.nodes ?? []
 
   return (
     <Fragment>
@@ -17,9 +17,9 @@ const PositionsPage = ({ data }) => {
       <Container sx={{ mt: 20 }}>
         <Typography level="h2" color="neutral">Positions</Typography>
         {
-          positions.map(position => (
+          positions.length ? positions.map(position => (
             <pre key={ position.id }>{JSON.stringify(position)}</pre>
-          ))
+          )) : 'No positions'
         }
       </Container>
     </Fragment>

--- a/src/pages/positions.js
+++ b/src/pages/positions.js
@@ -29,13 +29,20 @@ const PositionsPage = ({ data }) => {
 export default PositionsPage
 
 export const query = graphql`
-    query PositionsQuery {
-      allMondayItem {
-        nodes {
-          id
-          manager
-          title
-        }
+  query PositionsQuery {
+    allMondayItem {
+      nodes {
+        id
+        name
+        program
+        domain
+        group
+        division
+        semester
+        startDate
+        description
+        duration
       }
     }
-  `
+  }
+`

--- a/src/pages/positions.js
+++ b/src/pages/positions.js
@@ -1,27 +1,41 @@
 import React, { Fragment } from 'react'
-import { Sheet, Typography } from '@mui/joy'
+import { graphql } from 'gatsby'
+import { Typography } from '@mui/joy'
+import { Container } from '../components/container'
 import { Seo } from '../components/seo'
 
-const PositionsPage = () => (
-  <Fragment>
-    <Seo
-      title="Positions"
-      description="Commodo sunt tempor ad velit nostrud aute est aute incididunt enim labore."
-    />
-    <Sheet sx={{
-      border: '1px dashed grey',
-      height: '50vh',
-      width: '50vw',
-      margin: 'auto',
-      mt: 8,
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      alignItems: 'center',
-    }}>
-      <Typography level="h2" color="neutral">Positions</Typography>
-    </Sheet>
-  </Fragment>
-)
+const PositionsPage = ({ data }) => {
+
+  const positions = data.allMondayItem.nodes
+
+  return (
+    <Fragment>
+      <Seo
+        title="Positions"
+        description="Commodo sunt tempor ad velit nostrud aute est aute incididunt enim labore."
+      />
+      <Container sx={{ mt: 20 }}>
+        <Typography level="h2" color="neutral">Positions</Typography>
+        {
+          positions.map(position => (
+            <pre key={ position.id }>{JSON.stringify(position)}</pre>
+          ))
+        }
+      </Container>
+    </Fragment>
+  )
+}
 
 export default PositionsPage
+
+export const query = graphql`
+    query PositionsQuery {
+      allMondayItem {
+        nodes {
+          id
+          manager
+          title
+        }
+      }
+    }
+  `

--- a/src/pages/positions.js
+++ b/src/pages/positions.js
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react'
-import { graphql } from 'gatsby'
 import { Stack, Typography } from '@mui/joy'
 import { Container } from '../components/container'
 import { Seo } from '../components/seo'
@@ -26,33 +25,3 @@ const PositionsPage = ({ data }) => {
 }
 
 export default PositionsPage
-
-export const query = graphql`
-  query PositionsQuery {
-    allMondayColumn {
-      nodes {
-        id
-        field
-        title
-        options
-      }
-    }
-    allMondayItem {
-      nodes {
-        id
-        name
-        program
-        domain
-        group
-        division
-        semester
-        startDate
-        duration
-        abstract
-        description
-        pay
-        url
-      }
-    }
-  }
-`

--- a/src/pages/positions.js
+++ b/src/pages/positions.js
@@ -1,26 +1,25 @@
 import React, { Fragment } from 'react'
 import { graphql } from 'gatsby'
-import { Typography } from '@mui/joy'
+import { Stack, Typography } from '@mui/joy'
 import { Container } from '../components/container'
 import { Seo } from '../components/seo'
+import { FiltersTray, PositionsList } from '../components/positions'
 
 const PositionsPage = ({ data }) => {
-
-  const positions = data?.allMondayItem?.nodes ?? []
-
   return (
     <Fragment>
       <Seo
         title="Positions"
         description="Commodo sunt tempor ad velit nostrud aute est aute incididunt enim labore."
       />
-      <Container sx={{ mt: 20 }}>
+      <Container sx={{ mt: 20, p: 2 }}>
         <Typography level="h2" color="neutral">Positions</Typography>
-        {
-          positions.length ? positions.map(position => (
-            <pre key={ position.id }>{JSON.stringify(position)}</pre>
-          )) : 'No positions'
-        }
+
+        <Stack gap={ 2 }>
+          <FiltersTray />
+          <PositionsList />
+        </Stack>
+
       </Container>
     </Fragment>
   )
@@ -30,6 +29,14 @@ export default PositionsPage
 
 export const query = graphql`
   query PositionsQuery {
+    allMondayColumn {
+      nodes {
+        id
+        field
+        title
+        options
+      }
+    }
     allMondayItem {
       nodes {
         id
@@ -40,8 +47,11 @@ export const query = graphql`
         division
         semester
         startDate
-        description
         duration
+        abstract
+        description
+        pay
+        url
       }
     }
   }


### PR DESCRIPTION
this PR brings in a custom gatsby source plugin that pulls data from a single group in a single board (both fixed and hard-coded). the incoming data describes open positions to render on the website. like other source plugins, this runs at build-time. in production, i'm thinking we run nightly rebuild/deploys via gh actions.

@suejinkim20 i think the plugin is basically ready to go--at least ready to move into develop--but please give this a thorough testing. some kinks surely remain, but i think the basic sourcing and transformations that we want are in place.

you'll need an API token and and `.env.development` file that looks like
```
MONDAY_API_TOKEN=tokentokentokentokentokentokentokentoken
```