### PR TITLE
patch/monday plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -52,6 +52,7 @@ module.exports = {
         API_TOKEN: process.env.MONDAY_API_TOKEN,
       }
     },
+    `gatsby-transformer-monday`,
     /* manifest */
     {
       resolve: `gatsby-plugin-manifest`,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "start": "gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
+    "cleanstart": "gatsby clean && npm start",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "repository": {

--- a/plugins/gatsby-source-monday/fetch-board-data.js
+++ b/plugins/gatsby-source-monday/fetch-board-data.js
@@ -8,10 +8,9 @@ module.exports = async function fetchBoardData(options) {
     if (response?.status !== 200 || !response?.data) {
       return
     }
-    return response.data.data.boards[0]
+    return response.data.data
   } catch (error) {
     console.error(error)
     return []
   }
 }
-

--- a/plugins/gatsby-source-monday/query.js
+++ b/plugins/gatsby-source-monday/query.js
@@ -1,12 +1,38 @@
 module.exports = `query {
-  boards(ids:[5267641585]) {
+  dates: boards(ids:[6391840129]) {
+    id
+    columns(ids: ["date6","date4","date","date5","date42","status5"]) {
+      id
+      settings_str
+      title
+      type
+    }
+    
+    groups(ids:["topics"]) {
+      id
+      title
+      items_page {
+        items {
+          id
+          name
+          column_values(ids: ["date6","date4","date","date5","date42","status5"]) {
+            id
+            text
+          }
+        }
+      }
+    }
+  }
+
+  positions: boards(ids:[5267641585]) {
+    id
     columns {
       id
       settings_str
       title
       type
     }
-    groups(ids:["group_title"]) {
+    groups(ids: ["group_title", "topics", "new_group"]) {
       id
       title
       items_page {

--- a/plugins/gatsby-transformer-monday/assemble-columns.js
+++ b/plugins/gatsby-transformer-monday/assemble-columns.js
@@ -1,0 +1,29 @@
+const columnMap = require('./column-map')
+
+/* This function massages column data into a form suitable for building
+ *  position filters client-side. Our filters are select boxes, so we'll
+ *  only need to consider columns with enumerable possible values; that is 
+ *  only those with a type of `status`. Additionally, we only care about
+ *  those appearing in the `columnMap` object.
+ * 
+ * @param   array  columns    Monday response columns defined in query above.
+ * 
+ * @return  array  columns as objects.
+ * */
+module.exports = function assembleColumnData({ columns }) {
+  return columns.reduce((acc, column) => {
+    const { id, title, type, settings_str } = column
+    const { labels = {} } = JSON.parse(settings_str)
+    if (title in columnMap && type === 'status') {
+      acc.push({
+        id,
+        // `field` defines the property on position objects,
+        // client-side, that correpond to this column on positions.
+        field: columnMap[title],
+        options: Object.values(labels),
+        title,
+      })
+    }
+    return acc
+  }, [])
+}

--- a/plugins/gatsby-transformer-monday/assemble-dates.js
+++ b/plugins/gatsby-transformer-monday/assemble-dates.js
@@ -1,0 +1,36 @@
+/* This function massages row data into an array of date objects.
+ * 
+ * @param   array  columns    Monday response columns.
+ * 
+ * @return  array  dates as objects.
+ * */
+module.exports = function assembleDatesData({ columns, groups }) {
+
+  const years = columns
+    .filter(col => col.type === 'date')
+    .reduce((acc, col) => {
+      acc[col.id] = col.title
+      return acc
+    }, {})
+  const dates = groups[0].items_page.items.map(item => {
+    // the `Viewer` column has `id` of `status5` in the Monday board.
+    const audience = item.column_values.find(col => col.id === 'status5').text
+    const values = item.column_values
+      .filter(col => col.id.startsWith('date'))
+      .reduce((acc, { id, text }) => {
+        acc.push({
+          date: text,
+          year: years[id],
+        })
+        return acc
+      }, [])
+    return {
+      id: item.id,
+      name: item.name,
+      dates: values,
+      audience,
+    }
+  })
+
+  return dates
+}

--- a/plugins/gatsby-transformer-monday/assemble-positions.js
+++ b/plugins/gatsby-transformer-monday/assemble-positions.js
@@ -1,0 +1,32 @@
+const columnMap = require('./column-map')
+
+/* This function massages row data into an array of position objects
+ * with fields defined by `columnMap.positions` 
+ * 
+ * @param   array  groups     Monday response groups defined in query.
+ * 
+ * @return  array  positions as objects.
+ * */
+module.exports = function assemblePositionData({ groups }) {
+  if (!groups) { return }
+  return groups.reduce((acc, group) => {
+    acc.push(...group.items_page.items.reduce((itemAcc, item) => {
+        const { id, name, column_values } = item
+        const extractedColumnValues = column_values
+          .reduce((itemAcc, { column, text }) => {
+            if (column.title in columnMap) {
+              itemAcc[columnMap[column.title]] = text
+            }
+            return itemAcc
+          }, {})
+        itemAcc.push({
+          id,
+          name,
+          status: group.title,
+          ...extractedColumnValues,
+        })
+        return itemAcc
+      }, []))
+    return acc
+  }, [])
+}

--- a/plugins/gatsby-transformer-monday/column-map.js
+++ b/plugins/gatsby-transformer-monday/column-map.js
@@ -1,0 +1,14 @@
+// columns (keys) end up as item object properties (values)
+module.exports = {
+  'Minimum Education': 'education',
+  'RENCI Domain': 'domain',
+  'Group': 'group',
+  'Project/Team Name': 'division',
+  'Semester': 'semester',
+  'Anticipated Start Date': 'startDate',
+  'Estimated Duration (in weeks)': 'duration',
+  'Project Abstract': 'abstract',
+  'Position Description': 'description',
+  'Pay Range': 'pay',
+  'PD Link': 'url',
+}

--- a/plugins/gatsby-transformer-monday/gatsby-node.js
+++ b/plugins/gatsby-transformer-monday/gatsby-node.js
@@ -1,0 +1,98 @@
+const assemblePositionData = require('./assemble-positions')
+const assembleColumnData = require('./assemble-columns')
+const assembleDatesData = require('./assemble-dates')
+
+const DEBUG = true
+
+async function onCreateNode({
+  actions,
+  createContentDigest,
+  loadNodeContent,
+  node,
+  reporter,
+}) {
+  const timer = reporter.activityTimer(`transforming Monday.com boards`)
+
+  timer.setStatus(`Look for boards`)
+
+  if (!node) {
+    return
+  }
+
+  if (node.internal.type !== 'MondayBoard') {
+    return
+  }
+
+
+  const createPositionNodes = positionData => {
+    timer.setStatus(`Create PositionItem nodes`)
+    for (const position of positionData) {
+      actions.createNode({
+        ...position,
+        parent: null,
+        children: [],
+        internal: {
+          type: 'PositionItem',
+          contentDigest: createContentDigest(position)
+        }
+      })
+    }
+  }
+
+  const createColumnNodes = columnData => {
+    timer.setStatus(`Create PositionColumn nodes`)
+    for (const column of columnData) {
+      actions.createNode({
+        ...column,
+        parent: null,
+        children: [],
+        internal: {
+          type: 'PositionColumn',
+          contentDigest: createContentDigest(column)
+        }
+      })
+    }
+  }
+
+  const createDateNodes = datesData => {
+    timer.setStatus(`Create ImportantDate nodes`)
+    datesData.forEach(date => {
+      actions.createNode({
+        ...date,
+        parent: null,
+        children: [],
+        internal: {
+          type: 'ImportantDate',
+          contentDigest: createContentDigest(date)
+        }
+      })
+    })
+  }
+
+  try {
+    if (node.id === `6391840129`) {
+      const datesData = assembleDatesData(node)
+      if (DEBUG) { console.log(JSON.stringify(datesData, null, 2)) }
+      createDateNodes(datesData)
+      timer.setStatus(`Created ImportantDate nodes`)
+    }
+    
+    if (node.id === `5267641585`) {
+      const positionData = assemblePositionData(node)
+      if (DEBUG) { console.log(JSON.stringify(positionData, null, 2)) }
+      createPositionNodes(positionData)
+      timer.setStatus(`Created PositionItem nodes`)
+
+      const columnData = assembleColumnData(node)
+      if (DEBUG) { console.log(JSON.stringify(columnData, null, 2)) }
+      createColumnNodes(columnData)
+      timer.setStatus(`Created PositionColumn nodes`)
+    }
+  } catch (error) {
+    timer.panicOnBuild(error)
+    timer.setStatus(`Could not transform Monday.com position and dates boards.`)
+  }
+
+}
+
+exports.onCreateNode = onCreateNode

--- a/plugins/gatsby-transformer-monday/package.json
+++ b/plugins/gatsby-transformer-monday/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-source-monday",
+  "name": "gatsby-transformer-monday",
   "version": "1.0.0",
   "description": "",
   "main": "gatsby-node.js",
@@ -8,8 +8,5 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
-  "devDependencies": {
-    "axios": "^1.5.0"
-  }
+  "license": "ISC"
 }

--- a/src/components/positions/context.js
+++ b/src/components/positions/context.js
@@ -32,7 +32,7 @@ export const PositionsProvider = ({ children }) => {
   // coming directly from the monday source plugin.
   const data = useStaticQuery(graphql`
     query PositionsQuery {
-      allMondayColumn {
+      allPositionColumn {
         nodes {
           id
           field
@@ -40,7 +40,7 @@ export const PositionsProvider = ({ children }) => {
           options
         }
       }
-      allMondayItem {
+      allPositionItem(filter: {status: {regex: "/Closed/"}}) {
         nodes {
           id
           name
@@ -61,8 +61,8 @@ export const PositionsProvider = ({ children }) => {
   `)
 
   // extract the data nodes.
-  const columns = useMemo(() => data?.allMondayColumn?.nodes ?? [], [data])
-  const positions = useMemo(() => data?.allMondayItem?.nodes ?? [], [data])
+  const columns = useMemo(() => data?.allPositionColumn?.nodes ?? [], [data])
+  const positions = useMemo(() => data?.allPositionItem?.nodes ?? [], [data])
   // `filters` is an object whose keys are position
   // properties and whose values are ones to match
   // on positions in the respective property,

--- a/src/components/positions/context.js
+++ b/src/components/positions/context.js
@@ -40,7 +40,7 @@ export const PositionsProvider = ({ children }) => {
           options
         }
       }
-      allPositionItem(filter: {status: {regex: "/Closed/"}}) {
+      allPositionItem(filter: {status: {eq: "Reviewed"}}) {
         nodes {
           id
           name

--- a/src/components/positions/positions-list.js
+++ b/src/components/positions/positions-list.js
@@ -4,7 +4,7 @@ import { usePositions } from './context'
 import { PositionsCard } from './positions-card'
 
 export const PositionsList = () => {
-  const { filteredPositions } = usePositions()
+  const { filters, filteredPositions } = usePositions()
 
   if (filteredPositions.length === 0) {
     return (
@@ -19,7 +19,11 @@ export const PositionsList = () => {
           variant="soft"
           sx={{ p: 2 }}
         >
-          No positions match your search criteria!
+          {
+            filters.active.length
+              ? 'No positions match your search criteria!'
+              : 'Sorry, we don\'t currently have open positions!'
+          }
         </Typography>
       </Stack>
     )

--- a/src/components/sections/important-dates.js
+++ b/src/components/sections/important-dates.js
@@ -1,14 +1,26 @@
 import React from "react"
 import { Section } from "../section"
-import Table from "@mui/joy/Table"
-import Sheet from "@mui/joy/Sheet"
-import { DatesTable } from '../dates-table'
+import { Box } from "@mui/joy"
 
 export const ImportantDates = ({ content }) => {
-  
+  const rows = content.nodes.map(({ name, dates, audience }) => ({
+    name,
+    dates: dates.reduce((acc, d) => {
+      acc[d.year] = d.date
+      return acc
+    }, {}),
+    audience,
+  }))
+
+
   return (
     <Section title={content.title} backgroundColor="#fff" height="55vh">
-      <DatesTable content={content}/>
+      <Box
+        component="pre"
+        sx={{ whiteSpace: 'pre-wrap', fontSize: '75%' }}
+      >
+        {JSON.stringify(rows, null, 2)}
+      </Box>
     </Section>
   )
 }

--- a/src/components/sections/programs/starShipPanel.js
+++ b/src/components/sections/programs/starShipPanel.js
@@ -13,11 +13,29 @@ import {
   MainPanelButton
 } from '../../program-tabs'
 import ImportantDatesContent from '../../../content/sections/important-dates.yaml'
+import { useStaticQuery, graphql } from "gatsby"
 import { DatesTable } from '../../dates-table'
 import { Button } from '../../button'
 
+const datesQuery = graphql`query {
+  dates: allImportantDate {
+    nodes {
+      id
+      name
+      dates {
+        date
+        year
+      }
+    }
+  }
+}`
+>>>>>>> monday
 
 export const StarShipPanel = ({title, content}) => {
+  const data = useStaticQuery(datesQuery)
+
+  console.log(data)
+  
   return (
     <Container maxWidth="md" sx={{margin: '1.5rem auto'}}>
       <Typography level="h3" textAlign="center" gutterBottom>{title}</Typography>

--- a/src/components/sections/programs/starShipPanel.js
+++ b/src/components/sections/programs/starShipPanel.js
@@ -29,7 +29,6 @@ const datesQuery = graphql`query {
     }
   }
 }`
->>>>>>> monday
 
 export const StarShipPanel = ({title, content}) => {
   const data = useStaticQuery(datesQuery)

--- a/src/hooks/use-section-content.js
+++ b/src/hooks/use-section-content.js
@@ -25,33 +25,14 @@ export const useSectionContent = () => {
           }
         }    
       }
-      ImportantDates: sectionsYaml(section_id: { eq: "important-dates" }) {
-        title
-        date_titles {
-          date1
-          date2
-          date3
-          date4
-          date5
-          date6
-          date7
-          date8
-          date9
-          date10
-        }
-        dates {
-          semester
-          semester_dates {
-            date1
-            date2
-            date3
-            date4
-            date5
-            date6
-            date7
-            date8
-            date9
-            date10
+      ImportantDates: allImportantDate {
+        nodes {
+          id
+          name
+          audience
+          dates {
+            date
+            year
           }
         }
       }


### PR DESCRIPTION
this addresses the bug with our Monday.com plugin.

there is still an underlying issue, so this is more of a patch than a bug fix. when initially writing this, i didn't account for there being _zero_ nodes created in the case when positions weren't found in the response from Monday, _i.e._, when the "Reviewed" group is empty. to get around this not-creating-any-nodes business, i'm grabbing _all_ the positions, from _all_ the boards and building nodes for them. thus graphql will know about even the closed positions, _i.e._, from the "Closed Positions" board. however, on the front-end side, the graphql query (the one on the Gatsby side) now filters all positions to just the positions in the "Reviewed" group.

this solution ensures we'll at least receive some positions and create a non-zero number of position nodes, so graphql won't complain about missing data types.

this lead to further customizing the "no positions found" message on the actual positions list, which should be different if (1) there are no positions at all vs. (2) there are no positions found from the user's selected filters.